### PR TITLE
remove meta

### DIFF
--- a/include/verilog_ast.h
+++ b/include/verilog_ast.h
@@ -1092,7 +1092,7 @@ typedef enum ast_event_expression_type_e{
 
 //! Describes a single event expression
 typedef struct ast_event_expression_t ast_event_expression;
-    ast_metadata    meta;   //!< Node metadata.
+//    ast_metadata    meta;   //!< Node metadata. // HZ: remove this temporarily
 struct ast_event_expression_t {
     ast_event_expression_type type;
     union{


### PR DESCRIPTION



## Purpose

Remove global variable definition: `ast_metadata meta` in verilog_ast.h

### List of changes

- Remove definition of ast_meta meta

## Fixes:

- It now can be included in several files.
- This change is needed to merge the Verilog Analyser into the ILA repo.
