### PR TITLE
bug fix, strdup needed

### DIFF
--- a/src/verilog_ast.c
+++ b/src/verilog_ast.c
@@ -2840,7 +2840,7 @@ ast_number * ast_new_number(
 
     tr -> base = base;
     tr -> representation = representation;
-    tr -> as_bits = digits;
+    tr -> as_bits = ast_strdup(digits);
 
     return tr;
 }


### PR DESCRIPTION
## Purpose

Fix ast_new_number function bug in verilog_ast.c

### List of changes

- use `ast_strdup` to duplicate the input from yytext.

Original `ast_new_number` function does not copy the `as_bits` field from its input `yytext`, when later `yytext`'s content gets changed by the lexer, the AST lose access to its data field.

