### PR TITLE
bug fix

### DIFF
--- a/src/verilog_parser.y
+++ b/src/verilog_parser.y
@@ -1137,19 +1137,19 @@ port_declaration_l:
     ast_list * names = ast_list_new();
     ast_list_append(names, $4);
     $$ = ast_new_port_declaration(PORT_NONE, $1, $2,
-    AST_FALSE,AST_FALSE,NULL,names);
+    AST_FALSE,AST_FALSE,$3,names);
 }
 |            signed_o range_o port_identifier{
     ast_list * names = ast_list_new();
     ast_list_append(names, $3);
     $$ = ast_new_port_declaration(PORT_NONE, NET_TYPE_NONE, $1,
-    AST_FALSE,AST_FALSE,NULL,names);
+    AST_FALSE,AST_FALSE,$2,names);
 }
 | KW_REG     signed_o range_o port_identifier eq_const_exp_o{
     ast_list * names = ast_list_new();
     ast_list_append(names, $4);
     $$ = ast_new_port_declaration(PORT_NONE, NET_TYPE_NONE, AST_FALSE,
-    AST_TRUE,AST_FALSE,NULL,names);
+    AST_TRUE,AST_FALSE,$3,names);
 }
 | output_variable_type_o      port_identifier{
     ast_list * names = ast_list_new();


### PR DESCRIPTION
## Purpose

Bug fix: parser ignored port ranges when parsing port declarations.

### List of changes

- src/verilog_parser.y: change NULL to the relevant range pointer

