### PR TITLE
Disable One More Print-out

### DIFF
--- a/src/verilog_ast_mem.c
+++ b/src/verilog_ast_mem.c
@@ -74,7 +74,7 @@ has been freed.
 */
 void ast_free_all()
 {
-    printf("Freeing data for %u memory allocations.\n", memory_allocations);
+    //printf("Freeing data for %u memory allocations.\n", memory_allocations);
     size_t total_freed = 0;
 
     while(memory_head != NULL)


### PR DESCRIPTION
Just found out there is one more print-outs on the memory management of the Verilog parser. Let's remove it, since it is not something interesting.