### PR TITLE
Verilog Parser Update

### DIFF
--- a/include/verilogparser/verilog_ast.h
+++ b/include/verilogparser/verilog_ast.h
@@ -1810,6 +1810,27 @@ typedef struct ast_module_instantiation_t {
     ast_list              * module_instances;
 } ast_module_instantiation;
 
+
+/*! 
+@brief Describes the parameter override in module instantiation.
+@details If the resolved member is true, then you can access the declaration
+member, and find out everything about the module being instanced. Otherwise,
+you must access the module_identifier member, and can only know what the
+module is called.
+*/
+typedef struct ast_parameter_override_t {
+    ast_expression * ordered_parameter;
+    ast_port_connection * named_parameter;
+} ast_parameter_override;
+
+/*!
+@brief Creates and returns a new parameter override, either the first/second is NULL
+*/
+ast_parameter_override * ast_new_parameter_override(
+   ast_expression * ordered_parameter,
+   ast_port_connection * named_parameter
+);
+
 /*!
 @brief Creates and returns a new set of module instances with shared
 parameters.

--- a/include/verilogparser/verilog_ast.h
+++ b/include/verilogparser/verilog_ast.h
@@ -1838,25 +1838,6 @@ typedef struct ast_module_instantiation_t {
 } ast_module_instantiation;
 
 
-/*! 
-@brief Describes the parameter override in module instantiation.
-@details If the resolved member is true, then you can access the declaration
-member, and find out everything about the module being instanced. Otherwise,
-you must access the module_identifier member, and can only know what the
-module is called.
-*/
-typedef struct ast_parameter_override_t {
-    ast_expression * ordered_parameter;
-    ast_port_connection * named_parameter;
-} ast_parameter_override;
-
-/*!
-@brief Creates and returns a new parameter override, either the first/second is NULL
-*/
-ast_parameter_override * ast_new_parameter_override(
-   ast_expression * ordered_parameter,
-   ast_port_connection * named_parameter
-);
 
 /*!
 @brief Creates and returns a new set of module instances with shared

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 message(STATUS "Build Type: ${CMAKE_BUILD_TYPE}")
 
 #set(LIBRARY_NAME    verilogparser)
-set(EXECUTABLE_NAME parser)
+set(EXECUTABLE_NAME verilogparserexec)
 
 FIND_PACKAGE(BISON 3.0.4 REQUIRED)
 FIND_PACKAGE(FLEX 2.5.35 REQUIRED)

--- a/src/verilog_ast.c
+++ b/src/verilog_ast.c
@@ -2905,12 +2905,12 @@ char * ast_number_tostring(
             tr = n -> as_bits;
             break;
         case REP_INTEGER:
-            tr = calloc(11,sizeof(char));
-            sprintf(tr, "%d", n-> as_int);
+            tr = ast_calloc(11,sizeof(char));
+            snprintf(tr, 10, "%d", n-> as_int);
             break;
         case REP_FLOAT:
-            tr = calloc(21,sizeof(char));
-            sprintf(tr, "%20f", n -> as_float);
+            tr = ast_calloc(25,sizeof(char));
+            snprintf(tr, 24, "%20f", n -> as_float);
             break;
         default:
             tr = "NULL";

--- a/src/verilog_ast.c
+++ b/src/verilog_ast.c
@@ -1614,6 +1614,20 @@ ast_generate_block * ast_new_generate_block(
 
 
 /*!
+@brief Creates and returns a new parameter override, either the first/second is NULL
+*/
+ast_parameter_override * ast_new_parameter_override(
+   ast_expression * ordered_parameter,
+   ast_port_connection * named_parameter
+) {
+    ast_parameter_override * tr = ast_calloc(1,sizeof(ast_parameter_override));
+    tr->ordered_parameter = ordered_parameter;
+    tr->named_parameter = named_parameter;
+    return tr;
+}
+
+
+/*!
 @brief Creates and returns a new set of module instances with shared
 parameters.
 */

--- a/src/verilog_ast.c
+++ b/src/verilog_ast.c
@@ -1613,19 +1613,6 @@ ast_generate_block * ast_new_generate_block(
 }
 
 
-/*!
-@brief Creates and returns a new parameter override, either the first/second is NULL
-*/
-ast_parameter_override * ast_new_parameter_override(
-   ast_expression * ordered_parameter,
-   ast_port_connection * named_parameter
-) {
-    ast_parameter_override * tr = ast_calloc(1,sizeof(ast_parameter_override));
-    tr->ordered_parameter = ordered_parameter;
-    tr->named_parameter = named_parameter;
-    return tr;
-}
-
 
 /*!
 @brief Creates and returns a new set of module instances with shared

--- a/src/verilog_parser.y
+++ b/src/verilog_parser.y
@@ -2693,12 +2693,12 @@ module_instances : module_instance{
 ;
 
 ordered_parameter_assignment : expression{
-    $$=$1;
+    $$ = ast_new_parameter_override($1, NULL);
 };
 
 named_parameter_assignment : 
 DOT parameter_identifier OPEN_BRACKET expression_o CLOSE_BRACKET {
-    $$ = ast_new_named_port_connection($2,$4);
+    $$ = ast_new_parameter_override(NULL, ast_new_named_port_connection($2,$4));
 }
 ;
 

--- a/src/verilog_parser.y
+++ b/src/verilog_parser.y
@@ -2693,12 +2693,12 @@ module_instances : module_instance{
 ;
 
 ordered_parameter_assignment : expression{
-    $$ = ast_new_parameter_override($1, NULL);
+    $$ = $1;
 };
 
 named_parameter_assignment : 
 DOT parameter_identifier OPEN_BRACKET expression_o CLOSE_BRACKET {
-    $$ = ast_new_parameter_override(NULL, ast_new_named_port_connection($2,$4));
+    $$ = ast_new_named_port_connection($2,$4);
 }
 ;
 

--- a/src/verilog_scanner.l
+++ b/src/verilog_scanner.l
@@ -175,6 +175,7 @@ TRI0                "tri0"
 TRI1                "tri1"
 TRI                 "tri"
 TRIAND              "triand"
+NONE                "none"
 TRIOR               "trior"
 TRIREG              "trireg"
 UNSIGNED            "unsigned"
@@ -328,7 +329,7 @@ TERNARY             "?"
 <in_default_nettype>{TRIOR}   {
     BEGIN(INITIAL); 
     verilog_preproc_default_net(yy_preproc -> token_count, 
-        yylineno, NET_TYPE_TRIOR  );
+        yylineno, NET_TYPE_NONE  );
     }
 <in_default_nettype>{TRIREG}     {
     BEGIN(INITIAL); 
@@ -359,6 +360,11 @@ TERNARY             "?"
     BEGIN(INITIAL); 
     verilog_preproc_default_net(yy_preproc -> token_count, 
         yylineno, NET_TYPE_WOR    );
+    }
+<in_default_nettype>{NONE}    {
+    BEGIN(INITIAL); 
+    verilog_preproc_default_net(yy_preproc -> token_count, 
+        yylineno, NET_TYPE_NONE    );
     }
 
 {CD_TIMESCALE}           {


### PR DESCRIPTION
### List of changes

- Add support to `default_nettype none`
- Fix some memory management issue and use `snprintf` to replace `sprintf` to avoid buffer overflow
- Rename `parser` to `verilogparser` (this is for later merging with inv-syn branch, where there are also smt-lib2 and vcd parser)
